### PR TITLE
Add dot notation support to lookup() 

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -290,7 +290,7 @@ sub lookup {
         if(ref $context eq 'HASH' && exists($context->{$target})){
           $value = $context->{$target};
           last;
-        }elsif(UNIVERSAL::can($context, $target)){
+        }elsif($context->can($target)){
           $value = $context->$target();
           last;
         }


### PR DESCRIPTION
This should solve issue #9 it includes both hash and object method abilities and ignores keys with dots that match similar to the mustache.js implementation. 

I apologize for the lack of tests, I'm using this on an older system then it was built for and I'm lacking a few packages and have older versions of others. (It works beautifully btw. Perl 5.8.8 on RHEL 5)
