### PR TITLE
Remove misuse of length()

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -86,7 +86,7 @@ sub parse {
         my ($message, $errorPos) = @_;
         my @lineCount = split("\n", substr($tmpl, 0, $errorPos));
 
-        die $message . "\nLine " . length(@lineCount);
+        die $message . "\nLine " . @lineCount;
     };
 
     # Build the pattern, and instruct the regex engine to begin at `$start`.


### PR DESCRIPTION
scalar(@foo) is the way to get the number of elements in an array,
as opposed to length(@foo).