### PR TITLE
use tr/// for counting, not split

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -84,9 +84,9 @@ sub parse {
 
     my $error = sub {
         my ($message, $errorPos) = @_;
-        my @lineCount = split("\n", substr($tmpl, 0, $errorPos));
+        my $lineCount = substr($tmpl, 0, $errorPos) =~ tr/\n/\n/;
 
-        die $message . "\nLine " . length(@lineCount);
+        die $message . "\nLine " . $lineCount
     };
 
     # Build the pattern, and instruct the regex engine to begin at `$start`.


### PR DESCRIPTION
We can use tr/// to count character occurances in a string,
which avoids making a lot of copies of the string contents
that you would get with split.

This also avoids length(@array), which is a mistake in 999,999
times out of a million.  Thus, this fixes #11.