### PR TITLE
do not die when $ctx is non-hash non-blessed ref

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -9,6 +9,7 @@ use warnings;
 
 use CGI ();
 use File::Spec;
+use Scalar::Util 'blessed';
 
 use version 0.77; our $VERSION = qv("v0.5.1");
 
@@ -275,8 +276,7 @@ sub lookup {
             next unless exists $ctx->{$field};
             $value = $ctx->{$field};
             last;
-        } else {
-            next unless UNIVERSAL::can($ctx, $field);
+        } elsif (blessed($ctx) && $ctx->can($field)) {;
             $value = $ctx->$field();
             last;
         }


### PR DESCRIPTION
If you're passed a reference that isn't a hash reference or an object, you should (a) not use UNIVERSAL::can and (b) not barf when `$non_obj->can` throws an exception.

This fixes #8 and is similar to a commit in #10, but with extra safety and without the rest of the work.