### PR TITLE
Use HTML::Entities instead of CGI::escapeHTML

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -7,7 +7,7 @@ package Template::Mustache;
 use strict;
 use warnings;
 
-use CGI ();
+use HTML::Entities;
 use File::Spec;
 use Scalar::Util 'blessed';
 
@@ -219,7 +219,7 @@ sub generate {
                     $ctx->{$tag} = $value if ref $ctx eq 'HASH';
                 }
                 # An empty `$type` represents an HTML escaped tag.
-                $value = CGI::escapeHTML($value) unless $type;
+                $value = encode_entities($value) unless $type;
                 @result = $value;
             } elsif ($type eq '#') {
                 # Section Tags


### PR DESCRIPTION
CGI.pm is not included in latest Perl anymore. This commit seems to work, but I was unable to run the test suite, due to problems with "use version 0.77" (couldn't figure it out).