### PR TITLE
Add missing warnings and strict pragmas

### DIFF
--- a/benchmark.pl
+++ b/benchmark.pl
@@ -1,5 +1,8 @@
 #!/usr/bin/perl
 
+use strict;
+use warnings;
+
 use Benchmark;
 use Template::Mustache;
 

--- a/t/001_spec_compatibility.t
+++ b/t/001_spec_compatibility.t
@@ -1,5 +1,9 @@
 package SpecCompatibility;
 use base 'Test::Mini::TestCase';
+
+use strict;
+use warnings;
+
 use Test::Mini::Assertions;
 
 use Template::Mustache;

--- a/t/lambdas_receive_render_helper.t
+++ b/t/lambdas_receive_render_helper.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/parse_errors.t
+++ b/t/parse_errors.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_data_from_classes.t
+++ b/t/read_data_from_classes.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_data_from_hashes.t
+++ b/t/read_data_from_hashes.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_data_from_instances.t
+++ b/t/read_data_from_instances.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_data_from_subclass.t
+++ b/t/read_data_from_subclass.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_partials_from_file_system.t
+++ b/t/read_partials_from_file_system.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_partials_from_hashes.t
+++ b/t/read_partials_from_hashes.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_partials_from_partial_method.t
+++ b/t/read_partials_from_partial_method.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 
 case t::ReadPartialsFromPartialMethod {

--- a/t/read_partials_from_subs.t
+++ b/t/read_partials_from_subs.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_templates_from_file_system.t
+++ b/t/read_templates_from_file_system.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_templates_from_file_system_with_namespacing.t
+++ b/t/read_templates_from_file_system_with_namespacing.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 

--- a/t/read_templates_from_subclass.t
+++ b/t/read_templates_from_subclass.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::Mini::Unit;
 use Template::Mustache;
 


### PR DESCRIPTION
It is considered good practice to always use the `warnings` and `strict`
pragmas in source files.  This change updates the benchmark script and the
test files to use these pragmas.
