### PR TITLE
Replace bareword filehandles with variables

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -65,16 +65,18 @@ $WriteMakefileArgs{dist}->{PREOP} .= " -o $LIBDIR; ";
 $WriteMakefileArgs{dist}->{PREOP} .= "(cd $DISTDIR; find lib -name '*.pod' -type f >> MANIFEST)";
 
 # Create a MANIFEST.SKIP file.
-open(GITIGNORE, '<.gitignore');
-open(SKIP, '>MANIFEST.SKIP');
-print SKIP "#!include_default\n";
-print SKIP "MANIFEST.SKIP.*\n";
-print SKIP "^$DISTNAME.*\n";
-print SKIP "^\\..*\n";
-print SKIP <GITIGNORE>;
-print SKIP $SKIP_FILES;
-close SKIP;
-close GITIGNORE;
+open my $gih, '<', '.gitignore';
+my $gitignore = do { local $/; <$gih> };
+close $gih;
+
+open my $skip, '>', 'MANIFEST.SKIP';
+print $skip "#!include_default\n";
+print $skip "MANIFEST.SKIP.*\n";
+print $skip "^$DISTNAME.*\n";
+print $skip "^\\..*\n";
+print $skip $gitignore;
+print $skip $SKIP_FILES;
+close $skip;
 
 # Create a new MANIFEST.
 ExtUtils::Manifest::mkmanifest();

--- a/t/read_partials_from_file_system.t
+++ b/t/read_partials_from_file_system.t
@@ -14,14 +14,13 @@ case t::ReadPartialsFromFileSystem {
     setup {
         my $tmpdir = t::ReadPartialsFromFileSystem::Mustache->template_path();
 
-        local *FILE;
-        open FILE, '+>', "${tmpdir}/list1.mustache";
-        print FILE "a, b, c";
-        close FILE;
+        open my $fh, '+>', "${tmpdir}/list1.mustache";
+        print $fh "a, b, c";
+        close $fh;
 
-        open FILE, '+>', "${tmpdir}/list2.mustache";
-        print FILE "d, e, f";
-        close FILE;
+        open $fh, '+>', "${tmpdir}/list2.mustache";
+        print $fh "d, e, f";
+        close $fh;
 
         $self->{template} = '[ {{> list1}}, {{> list2}} ]';
         $self->{expected} = '[ a, b, c, d, e, f ]';

--- a/t/read_templates_from_file_system.t
+++ b/t/read_templates_from_file_system.t
@@ -27,11 +27,10 @@ case t::ReadTemplatesFromFileSystem {
         setup {
             my $tmp = $self->{tmpdir};
 
-            local *FILE;
             my $filename = "$tmp/t/ReadTemplatesFromFileSystem/Mustache.mustache";
-            open FILE, '+>', $filename;
-            print FILE '{{name}} the {{occupation}} ({{is_instance}})';
-            close FILE;
+            open my $fh, '+>', $filename;
+            print $fh '{{name}} the {{occupation}} ({{is_instance}})';
+            close $fh;
         }
 
         test class_render {
@@ -49,11 +48,10 @@ case t::ReadTemplatesFromFileSystem {
         setup {
             my $tmp = $self->{tmpdir};
 
-            local *FILE;
             my $filename = "$tmp/OtherTemplate.mustache";
-            open FILE, '+>', $filename;
-            print FILE '{{name}} -- {{occupation}} ({{is_instance}})';
-            close FILE;
+            open my $fh, '+>', $filename;
+            print $fh '{{name}} -- {{occupation}} ({{is_instance}})';
+            close $fh;
         }
 
         setup {
@@ -81,11 +79,10 @@ case t::ReadTemplatesFromFileSystem {
         setup {
             my $tmp = $self->{tmpdir};
 
-            local *FILE;
             my $filename = "$tmp/TemplateFile.mustache";
-            open FILE, '+>', $filename;
-            print FILE '{{name}}, {{occupation}}';
-            close FILE;
+            open my $fh, '+>', $filename;
+            print $fh '{{name}}, {{occupation}}';
+            close $fh;
         }
 
         test rendering {

--- a/t/read_templates_from_file_system_with_namespacing.t
+++ b/t/read_templates_from_file_system_with_namespacing.t
@@ -24,10 +24,9 @@ case t::ReadTemplatesFromFileSystemWithNamespace {
         my $tmp = $mustache->template_path();
         mkdir "$tmp/ReadTemplatesFromFileSystemWithNamespace";
 
-        local *FILE;
-        open FILE, '+>', "$tmp/ReadTemplatesFromFileSystemWithNamespace/Mustache.mustache";
-        print FILE '{{name}} -- {{occupation}} ({{is_instance}})';
-        close FILE;
+        open my $fh, '+>', "$tmp/ReadTemplatesFromFileSystemWithNamespace/Mustache.mustache";
+        print $fh '{{name}} -- {{occupation}} ({{is_instance}})';
+        close $fh;
     }
 
     test class_render {


### PR DESCRIPTION
Bareword filehandles should be avoided and are no longer considered good
Perl practice.  This commit replaces the instances of bareword filehandles
with appropriately scoped variables in scripts and test files.
