### PR TITLE
Ignore RequireFilenameMatchesPackage perlcritic warning

### DIFF
--- a/t/001_spec_compatibility.t
+++ b/t/001_spec_compatibility.t
@@ -1,4 +1,4 @@
-package SpecCompatibility;
+package SpecCompatibility; ## no critic (RequireFilenameMatchesPackage)
 use base 'Test::Mini::TestCase';
 use Test::Mini::Assertions;
 

--- a/t/lambdas_receive_render_helper.t
+++ b/t/lambdas_receive_render_helper.t
@@ -3,6 +3,7 @@ use Template::Mustache;
 
 case t::LambdasReceiveRenderHelper {
     {
+        ## no critic (RequireFilenameMatchesPackage)
         package t::LambdasReceiveRenderHelper::Mustache;
         use base 'Template::Mustache';
 

--- a/t/read_data_from_subclass.t
+++ b/t/read_data_from_subclass.t
@@ -3,6 +3,7 @@ use Template::Mustache;
 
 case t::ReadDataFromSubclass {
     {
+        ## no critic (RequireFilenameMatchesPackage)
         package t::ReadDataFromSubclass::Mustache;
         use base 'Template::Mustache';
 

--- a/t/read_partials_from_file_system.t
+++ b/t/read_partials_from_file_system.t
@@ -3,6 +3,7 @@ use Template::Mustache;
 
 case t::ReadPartialsFromFileSystem {
     {
+        ## no critic (RequireFilenameMatchesPackage)
         package t::ReadPartialsFromFileSystem::Mustache;
         use base 'Template::Mustache';
         use File::Temp qw/ tempdir /;

--- a/t/read_partials_from_partial_method.t
+++ b/t/read_partials_from_partial_method.t
@@ -2,6 +2,7 @@ use Test::Mini::Unit;
 
 case t::ReadPartialsFromPartialMethod {
     {
+        ## no critic (RequireFilenameMatchesPackage)
         package t::ReadPartialsFromPartialMethod::Mustache;
         use base 'Template::Mustache';
 

--- a/t/read_templates_from_file_system.t
+++ b/t/read_templates_from_file_system.t
@@ -3,6 +3,7 @@ use Template::Mustache;
 
 case t::ReadTemplatesFromFileSystem {
     {
+        ## no critic (RequireFilenameMatchesPackage)
         package t::ReadTemplatesFromFileSystem::Mustache;
         use base 'Template::Mustache';
         use File::Temp qw/ tempdir /;

--- a/t/read_templates_from_file_system_with_namespacing.t
+++ b/t/read_templates_from_file_system_with_namespacing.t
@@ -3,6 +3,7 @@ use Template::Mustache;
 
 case t::ReadTemplatesFromFileSystemWithNamespace {
     {
+        ## no critic (RequireFilenameMatchesPackage)
         package t::ReadTemplatesFromFileSystemWithNamespace::Mustache;
         use base 'Template::Mustache';
         use File::Temp qw/ tempdir /;

--- a/t/read_templates_from_subclass.t
+++ b/t/read_templates_from_subclass.t
@@ -3,6 +3,7 @@ use Template::Mustache;
 
 case t::ReadTemplatesFromSubclass {
     {
+        ## no critic (RequireFilenameMatchesPackage)
         package t::ReadTemplatesFromSubclass::Mustache;
         use base 'Template::Mustache';
 


### PR DESCRIPTION
The instances in the code where packages are declared seem to have very good
reasons to vary from the considered best practice.  Hence the instances
where the package name doesn't match the filename can safely be ignored.
