### PR TITLE
Fix spec test suite

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -276,7 +276,8 @@ sub lookup {
             next unless exists $ctx->{$field};
             $value = $ctx->{$field};
             last;
-        } elsif ($ctx && (blessed($ctx) || ! ref $ctx) && $ctx->can($field)) {;
+        }
+        elsif ($ctx && (blessed($ctx) || ! ref $ctx) && _can_run_field($ctx, $field)) {
             # We want to accept class names and objects, but not unblessed refs
             # or undef. -- rjbs, 2015-06-12
             $value = $ctx->$field();
@@ -285,6 +286,21 @@ sub lookup {
     }
 
     return ($ctx, $value);
+}
+
+sub _can_run_field {
+    my ($ctx, $field) = @_;
+
+    my $can_run_field;
+    if ( $] < 5.018 ) {
+        eval { $ctx->can($field) };
+        $can_run_field = not $@;
+    }
+    else {
+        $can_run_field = $ctx->can($field);
+    }
+
+    return $can_run_field;
 }
 
 use namespace::clean;

--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -272,12 +272,13 @@ sub lookup {
 
     for my $index (0..$#{[@context]}) {
         $ctx = $context[$index];
+        my $blessed_or_not_ref = blessed($ctx) || !ref $ctx;
         if (ref $ctx eq 'HASH') {
             next unless exists $ctx->{$field};
             $value = $ctx->{$field};
             last;
         }
-        elsif ($ctx && (blessed($ctx) || ! ref $ctx) && _can_run_field($ctx, $field)) {
+        elsif ($ctx && $blessed_or_not_ref && _can_run_field($ctx, $field)) {
             # We want to accept class names and objects, but not unblessed refs
             # or undef. -- rjbs, 2015-06-12
             $value = $ctx->$field();


### PR DESCRIPTION
It turns out that the spec test suite had two failures when running with Perl 5.16 and below, however tested correctly on 5.18 and above.  These patches fix this problem allowing the test suite to run correctly in all Perl versions.  More detailed information about the fix is available in the commit messages.  This code has been checked on Perls 5.8 through 5.22.
