### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+
+language: perl
+
+perl:
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+    - "5.8"
+
+install:
+    - cpanm --installdeps --notest .
+    - git submodule update --init


### PR DESCRIPTION
[Travis-CI](https://travis-ci.org) is a free continuous integration service
(for open source projects).  This commit adds the configuration file for
this service so that the distribution can be built and tested.  It will test
the distribution against Perl versions 5.8 through 5.22.

Note that the dependencies are installed without running their test suites since the currently released version of `Test::Mini` fails its test suite (this has been fixed in the project's GitHub repo, but is yet to be released to CPAN).  Nevertheless, the currently released version of `Test::Mini` is sufficient to run the tests for `Template::Mustache` such that they pass.  Note also that the fix for the spec test suite in PR #33) is required in order that the Perl versions 5.16 and below can pass the tests correctly.
